### PR TITLE
Restrict workflow to client changes

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/build-and-deploy.yml'
+      - 'src/Client/**'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
+    paths:
+      - '.github/workflows/build-and-deploy.yml'
+      - 'src/Client/**'
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
## Summary
- only run the build-and-deploy workflow when the workflow file or the client code changes

## Testing
- `dotnet test` *(no tests found)*