### PR TITLE
Add Taggy detection API integration

### DIFF
--- a/src/Api/DetectionFunction.cs
+++ b/src/Api/DetectionFunction.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using Shared;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Api;
+
+public class DetectionFunction(ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<DetectionFunction>();
+
+    [Function("Detections")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+    {
+        var detection = await req.ReadFromJsonAsync<Detection>();
+        if (detection is not null)
+        {
+            _logger.LogInformation("Received detection {Detection}", detection);
+        }
+        var response = req.CreateResponse(HttpStatusCode.Accepted);
+        return response;
+    }
+}
+

--- a/src/Shared/Detection.cs
+++ b/src/Shared/Detection.cs
@@ -1,0 +1,8 @@
+namespace Shared;
+
+public record Detection(int Id, TimeOnly Time, int TenthSeconds, int ParticipantId, int EventId)
+{
+    public override string ToString() =>
+        $"#{Id} at {Time:HH:mm:ss}.{TenthSeconds} - participant {ParticipantId}, event {EventId}";
+}
+

--- a/src/TaggyClient/TaggyClient.csproj
+++ b/src/TaggyClient/TaggyClient.csproj
@@ -5,4 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add shared Detection model
- update TaggyClient to POST detections to the API when received
- reference Shared project in TaggyClient
- implement new Azure Function endpoint to accept detections

## Testing
- `dotnet build` *(fails: No route to host)*